### PR TITLE
fix: Internal getVerifierParameters

### DIFF
--- a/contracts/src/Sp1LidoAccountingReportContract.sol
+++ b/contracts/src/Sp1LidoAccountingReportContract.sol
@@ -222,7 +222,7 @@ contract Sp1LidoAccountingReportContract is SecondOpinionOracle, AccessControlEn
         // Check that public values from ZK program match expected blockchain state
         _verify_public_values(public_values);
 
-        Sp1VerifierParameters memory sp1_parameters = getVerifierParameters(metadata.bc_slot);
+        Sp1VerifierParameters memory sp1_parameters = _getVerifierParameters(metadata.bc_slot);
 
         // Verify ZK-program and public values
         try ISP1Verifier(sp1_parameters.verifier).verifyProof(sp1_parameters.vkey, publicValues, proof) {
@@ -242,7 +242,7 @@ contract Sp1LidoAccountingReportContract is SecondOpinionOracle, AccessControlEn
     /// @notice Gets SP1 parameters for a given slot
     /// @param stateSlot Slot to get SP1 paramters for
     /// @return parameters New SP1 parameters to use
-    function getVerifierParameters(uint256 stateSlot) internal view returns (Sp1VerifierParameters memory) {
+    function _getVerifierParameters(uint256 stateSlot) internal view returns (Sp1VerifierParameters memory) {
         return stateSlot < verifier_parameters_pivot_slot ? verifier_parameters_before_pivot : verifier_parameters_after_pivot;
     }
 

--- a/contracts/src/Sp1LidoAccountingReportContract.sol
+++ b/contracts/src/Sp1LidoAccountingReportContract.sol
@@ -242,7 +242,7 @@ contract Sp1LidoAccountingReportContract is SecondOpinionOracle, AccessControlEn
     /// @notice Gets SP1 parameters for a given slot
     /// @param stateSlot Slot to get SP1 paramters for
     /// @return parameters New SP1 parameters to use
-    function getVerifierParameters(uint256 stateSlot) public view returns (Sp1VerifierParameters memory) {
+    function getVerifierParameters(uint256 stateSlot) internal view returns (Sp1VerifierParameters memory) {
         return stateSlot < verifier_parameters_pivot_slot ? verifier_parameters_before_pivot : verifier_parameters_after_pivot;
     }
 

--- a/contracts/test/Sp1LidoAccountingReportContractTestWrapper.sol
+++ b/contracts/test/Sp1LidoAccountingReportContractTestWrapper.sol
@@ -28,4 +28,8 @@ contract Sp1LidoAccountingReportContractTestWrapper is Sp1LidoAccountingReportCo
     function recordLidoValidatorStateHash(uint256 slot, bytes32 state_merkle_root) public {
         _recordLidoValidatorStateHash(slot, state_merkle_root);
     }
+
+    function getVerifierParameters(uint256 stateSlot) public view returns (Sp1VerifierParameters memory) {
+        return super.getVerifierParameters(stateSlot);
+    }
 }

--- a/contracts/test/Sp1LidoAccountingReportContractTestWrapper.sol
+++ b/contracts/test/Sp1LidoAccountingReportContractTestWrapper.sol
@@ -30,6 +30,6 @@ contract Sp1LidoAccountingReportContractTestWrapper is Sp1LidoAccountingReportCo
     }
 
     function getVerifierParameters(uint256 stateSlot) public view returns (Sp1VerifierParameters memory) {
-        return super.getVerifierParameters(stateSlot);
+        return _getVerifierParameters(stateSlot);
     }
 }


### PR DESCRIPTION
```
Ran 24 tests for test/Sp1LidoAccountingReportContractTest.t.sol:Sp1LidoAccountingReportContractTest
[PASS] test_beaconStateSlotEmpty_reverts() (gas: 107115)
[PASS] test_newStateSlot_mismatchBeaconStateSlot_reverts() (gas: 101875)
[PASS] test_noStateRecordedForOldStateSlot_reverts() (gas: 101776)
[PASS] test_oldStateSlotAheadOfBcSlot_reverts() (gas: 150407)
[PASS] test_oldStateSlotAheadSameAsBcSlot_reverts() (gas: 99151)
[PASS] test_oldStateWrongMerkleRoot_reverts() (gas: 101635)
[PASS] test_refSlotEmpty_beaconStateSlotFirstNonEmptyPreceding_passes() (gas: 274426)
[PASS] test_refSlotEmpty_beaconStateSlotFirstPrecedingNonEmpty_passes() (gas: 274403)
[PASS] test_refSlotEmpty_beaconStateSlotNotFirstNonEmptyPreceding_reverts() (gas: 130644)
[PASS] test_refSlotHasBlock_beaconStateSlotEqualToRefSlot_passes() (gas: 255522)
[PASS] test_refSlotHasBlock_beaconStateSlotNotEqualToRefSlot_reverts() (gas: 114017)
[PASS] test_refSlotInFuture_reverts() (gas: 121038)
[PASS] test_refSlotLessThanBeaconStateSlot_reverts() (gas: 117148)
[PASS] test_setPivot_inRole_pivotImmediately_success() (gas: 104240)
[PASS] test_setPivot_inRole_pivotInPast_reverts() (gas: 62149)
[PASS] test_setPivot_inRole_success() (gas: 104442)
[PASS] test_setPivot_nonRole_reverts() (gas: 55467)
[PASS] test_validProof() (gas: 252695)
[PASS] test_validProofWrongExpectedBeaconBlockHash_reverts() (gas: 91883)
[PASS] test_validProofWrongLidoWithdrawalCredentials_reverts() (gas: 99179)
[PASS] test_validProof_reportTwice_rejected() (gas: 261327)
[PASS] test_validatorRejects_reverts() (gas: 102876)
[PASS] test_withdrawalVault_ReportAndMetadataBalanceMismatch_reverts() (gas: 96872)
[PASS] test_withdrawalVault_WrongWithdrawalVaultAddress_reverts() (gas: 101724)
Suite result: ok. 24 passed; 0 failed; 0 skipped; finished in 2.25ms (14.05ms CPU time)
```