### PR TITLE
chore: Add new metric for report submission

### DIFF
--- a/crates/script/src/lib/prometheus_metrics.rs
+++ b/crates/script/src/lib/prometheus_metrics.rs
@@ -79,6 +79,7 @@ pub struct Report {
     pub withdrawal_vault_balance_gwei: UIntGauge,
     pub state_new_validators: UIntGauge,
     pub state_changed_validators: UIntGauge,
+    pub submission_success_total: UIntCounterVec,
 }
 
 pub struct Service {
@@ -140,6 +141,12 @@ impl Registar for Report {
             "report",
             "state_changed_validators",
             self.state_changed_validators
+        )?;
+        register_metric!(
+            registry,
+            "report",
+            "submission_success_total",
+            self.submission_success_total
         )?;
         Ok(())
     }
@@ -370,6 +377,12 @@ impl Metrics {
             ),
             state_new_validators: gauge(namespace, "report__state_new_validators", "New validators"),
             state_changed_validators: gauge(namespace, "report__state_changed_validators", "Changed validators"),
+            submission_success_total: counter_vec(
+                namespace,
+                "report__submission_success_total",
+                "Total number of successful report submissions",
+                &["status"],
+            ),
         };
 
         let service_duration_buckets = vec![0.1, 0.25, 0.5, 1.0, 3.0, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0];

--- a/crates/script/src/lib/scripts/submit.rs
+++ b/crates/script/src/lib/scripts/submit.rs
@@ -255,7 +255,7 @@ async fn run_with_span(
                 .metrics
                 .report
                 .submission_success_total
-                .with_label_values(&["success"])
+                .with_label_values(&[prometheus_metrics::outcome::SUCCESS])
                 .inc();
         })
         .inspect_err(|e| {

--- a/crates/script/src/lib/scripts/submit.rs
+++ b/crates/script/src/lib/scripts/submit.rs
@@ -251,6 +251,12 @@ async fn run_with_span(
                 .with_label_values(&[prometheus_metrics::outcome::SUCCESS])
                 .inc();
             runtime.metrics.execution.gas_cost.set(tx_receipt.gas_used);
+            runtime
+                .metrics
+                .report
+                .submission_success_total
+                .with_label_values(&["success"])
+                .inc();
         })
         .inspect_err(|e| {
             tracing::error!("Failed to submit report: {e:?}");


### PR DESCRIPTION
This PR adds a new Prometheus metric to track successful on-chain report submissions from the submit script.

# Changes:

- Introduces a new report__submission_success_total counter metric under the Report metrics group.
- Registers the new metric and increments it on successful submit_report_data transactions.


Alert will be:
```
increase(report__submission_success_total{status="success"}[24h]) == 0
```