### PR TITLE
Pin all build dependencies for reproducible vkeys

### DIFF
--- a/.github/workflows/combined-ci.yml
+++ b/.github/workflows/combined-ci.yml
@@ -17,21 +17,21 @@ jobs:
       
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile default
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88.0 --profile default
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           source "$HOME/.cargo/env"
           rustup component add rustfmt clippy
-      
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
-      
+          version: v1.4.4
+
       - name: Install SP1 toolchain
         run: |
           curl -L https://sp1.succinct.xyz | bash
           export PATH="$HOME/.sp1/bin:$PATH"
-          sp1up --version 5.2.1
+          sp1up --version 5.2.3
           rustup toolchain list
           echo "$HOME/.sp1/bin" >> $GITHUB_PATH
       
@@ -85,20 +85,20 @@ jobs:
       
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile default
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88.0 --profile default
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           source "$HOME/.cargo/env"
-      
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
-      
+          version: v1.4.4
+
       - name: Install SP1 toolchain
         run: |
           curl -L https://sp1.succinct.xyz | bash
           export PATH="$HOME/.sp1/bin:$PATH"
-          sp1up --version 5.2.1
+          sp1up --version 5.2.3
           rustup toolchain list
           echo "$HOME/.sp1/bin" >> $GITHUB_PATH
       

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,21 +25,21 @@ jobs:
       
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile default
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88.0 --profile default
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           source "$HOME/.cargo/env"
           rustup component add llvm-tools-preview
-      
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
-      
+          version: v1.4.4
+
       - name: Install SP1 toolchain
         run: |
           curl -L https://sp1.succinct.xyz | bash
           export PATH="$HOME/.sp1/bin:$PATH"
-          sp1up --version 5.2.1
+          sp1up --version 5.2.3
           rustup toolchain list
           echo "$HOME/.sp1/bin" >> $GITHUB_PATH
       
@@ -104,8 +104,8 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
-      
+          version: v1.4.4
+
       - name: Cache Forge dependencies
         uses: actions/cache@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,6 +1822,20 @@ name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
 
 [[package]]
 name = "byteorder"
@@ -2686,6 +2700,7 @@ dependencies = [
  "ff 0.13.1",
  "generic-array 0.14.9",
  "group 0.13.0",
+ "hkdf",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -2811,7 +2826,7 @@ dependencies = [
 [[package]]
 name = "ethereum_hashing"
 version = "0.7.0"
-source = "git+https://github.com/sp1-patches/ethereum_hashing?branch=sp1-patch-0.7.0#64f930bd7cf6aea108adad77ebb1997f1b2596ee"
+source = "git+https://github.com/sp1-patches/ethereum_hashing?rev=64f930bd7cf6aea108adad77ebb1997f1b2596ee#64f930bd7cf6aea108adad77ebb1997f1b2596ee"
 dependencies = [
  "cpufeatures",
  "ring",
@@ -3359,6 +3374,15 @@ name = "hex-literal"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -6254,9 +6278,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52508b6f06d427e078b2d87e096e0adc3c3d4e0961d565d84961ce9d9c27c791"
+checksum = "a7bcc9e463a19749f6080f69ee6410aadda0576115d60bed68d2ebc2d8af3fe4"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -6268,9 +6292,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117e991e137c9121eac26b2fd06daaa8f9e7c118a167d9a977e0048ac2142fac"
+checksum = "3fb8bc70057a88164e479e367e2f83f7e7fba52d66acfbeef3b2174dc98c3627"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6307,9 +6331,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b70e76953d1c4d507136b373bc198df0271d011c9acaa9b1eb8614dd65a0e04"
+checksum = "fe446bea36feb189af83cda6ea5420150e877764e2ed4ab4cb2ee5cd3e20355c"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -6363,9 +6387,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3552cda9c153e7604ba9ec53822214e32975dc9e484eff832ccddbc018524fb"
+checksum = "ae79f89725c6e21dadb62be31a1c218292f5489559a848faf533419c722a3b3b"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -6380,9 +6404,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e29cb79716167e58c0719d572e686880172f1816cd85e0acab74ea0ff3c795e"
+checksum = "a6a7ce14c504360349f3eda564a0c9de286c35e1dfbcc979921a3384db02ae82"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6402,9 +6426,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac59616976c008e862f99d26fd0c1c037d464df33d9ca548be88f938f0b1bcf"
+checksum = "9e1144840e0b75e988f3b8d24ffd015bc5fd76599f7864bfd994f3eaf2eb261a"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6412,20 +6436,21 @@ dependencies = [
 
 [[package]]
 name = "sp1-helper"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99bf2f3784641d198ffbe63dbd8929e476737a6d1eefe6688947179b55ea153"
+checksum = "91ae2e3edfe237410b707d267ad5f05fd2d92c6fd18c596f9398d9e2fd5e2573"
 dependencies = [
  "sp1-build",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.2"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce8ad0f153443d09d398eccb650a0b2dcbf829470e394e4bf60ec4379c7af93"
+checksum = "b73b8ff343f2405d5935440e56b7aba5cee6d87303f0051974cbd6f5de502f57"
 dependencies = [
  "bincode",
+ "elliptic-curve",
  "serde",
  "sp1-primitives",
 ]
@@ -6578,9 +6603,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.2"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0244dee3a7a0f88cf71c3edf518f4fc97794ae870a107cbe7c810ac3fbf879cb"
+checksum = "7e69a03098f827102c54c31a5e57280eb45b2c085de433b3f702e4f9e3ec1641"
 dependencies = [
  "bincode",
  "blake3",
@@ -6598,9 +6623,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace68f9905360448e0b447a881b689204e7b2ee3a1481b49e91900564d50beb2"
+checksum = "cfc62e3139fdb1671067987f78ca85a24ea34dbc2f61dbbe3f92b9739e7aa2b9"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6635,6 +6660,7 @@ dependencies = [
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
  "sp1-stark",
+ "sp1-verifier",
  "thiserror 1.0.69",
  "tracing",
  "tracing-appender",
@@ -6643,9 +6669,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac2a5bd8b39ebf83160a13595e5197f3f194ddcc6d77af01a14b02a4e7bed12"
+checksum = "44f16af7722bb0f7adabbfc0e60b7fe71ca546959d251c450afb79daaa589c56"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
@@ -6678,9 +6704,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5611ead360e9875f426c5add60ce8082bfee28302a5c7dbfa39cad02e9178f88"
+checksum = "7c83564beb23361e0b93d64f3b8d4a503eac8ced246648f727d44b0827165014"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -6700,9 +6726,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79029408bee7a503394ab9d738432e709475976034348d5107a1d1a0b06dc287"
+checksum = "8c209fa6e384ff56ea7761ccc65426da08516d72ae55b6d8e4021b58bd4022f8"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -6743,9 +6769,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "5.2.2"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f557f5bbfc8bc21b2bc319d3a375b46ea4522c00b875f02d73e4c0709b023"
+checksum = "1b190465c0c0377f3cacfac2d0ac8a630adf8e1bfac8416be593753bfa4f668e"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6753,9 +6779,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae30a1148f569a2bd133b5c666654132e0088c1762b826141cca7209106bfb23"
+checksum = "5e146d24ce91c08e36b270a73de9817b9847e759a3d66923b009c67f24a3b9b2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6779,9 +6805,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fcae977c189e0f8e08dafa115add26d39b972b6e672b8e9f772db4655259de"
+checksum = "f9655067dcadba91f01491729cc78a60ad3a5ffaaf9adab817502f729ddb3761"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -6832,9 +6858,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0cdde80366245a374d29fecdde2881286002a6e3f51b84f54b86560ed026e5"
+checksum = "40477690a0bb6d7102322947407439a8f1d05aecd535f0081db05e9a31f808f2"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -6865,10 +6891,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp1-zkvm"
-version = "5.2.2"
+name = "sp1-verifier"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9cad934f30e245be5c0c55aac0810cf3bbd86187b384e0e95f3afac7cd41b3"
+checksum = "1904bbb3c2d16a7a11db32900f468149bc66253825e222f2db76f64fb8ffd1ab"
+dependencies = [
+ "blake3",
+ "cfg-if",
+ "hex",
+ "lazy_static",
+ "sha2",
+ "substrate-bn-succinct",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "sp1-zkvm"
+version = "5.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e767ed85f89b1c8d84188c2cc035833079529bb0ddd8f7bd252de91ce562acc7"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
@@ -6900,7 +6941,7 @@ dependencies = [
 [[package]]
 name = "ssz_types"
 version = "0.11.0"
-source = "git+https://github.com/lidofinance/ssz_types#c81e87812a9449b89d6d7a31a375090466b90544"
+source = "git+https://github.com/lidofinance/ssz_types?rev=c81e87812a9449b89d6d7a31a375090466b90544#c81e87812a9449b89d6d7a31a375090466b90544"
 dependencies = [
  "arbitrary",
  "ethereum_hashing",
@@ -6985,6 +7026,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "substrate-bn-succinct"
+version = "0.6.0-v5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba32f1b74728f92887c3ad17c42bf82998eb52c9091018f35294e9cd388b0c8"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "cfg-if",
+ "crunchy",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "rand 0.8.5",
+ "rustc-hex",
+ "sp1-lib",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,20 +16,20 @@ license = "MIT"
 
 [workspace.dependencies]
 alloy = { version = "1", features = ["contract", "json", "providers", "signer-local", "signers", "sol-types", "network"] }
-alloy-primitives = { version = "1.3", features = ["serde", "rlp"] }
-alloy-sol-types = "1"
-arbitrary = "1.4"
+alloy-primitives = { version = "=1.4.1", features = ["serde", "rlp"] }
+alloy-sol-types = "=1.4.1"
+arbitrary = "=1.4.2"
 alloy-rlp = { version = "0.3.12", features = ["derive"] }
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["clock"] }
 chrono-tz = "0.10"
-derive_more = { version = "2.0", features = ["debug"] }
+derive_more = { version = "=2.0.1", features = ["debug"] }
 dotenvy = "0.15.7"
 ethereum_hashing = "0.7.0"
-ethereum_serde_utils = "0.8"
-ethereum_ssz = "0.9"
+ethereum_serde_utils = "=0.8.0"
+ethereum_ssz = "=0.9.1"
 ethereum_ssz_derive = "=0.9"
-ethereum-types = {version = "0.16", features = ["arbitrary"] }
+ethereum-types = { version = "=0.16.0", features = ["arbitrary"] }
 eth_trie = "0.6.1"
 eyre = "0.6.12"
 hex = "0.4.3"
@@ -49,10 +49,10 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_derive = "1.0"
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 simple_logger = "5.0"
-sp1-derive = "5.2.1"
-sp1-helper = "5.2.1"
-sp1-sdk = {version = "5.2.1", features = ["network"] }
-sp1-zkvm = "5.2.1"
+sp1-derive = "=5.2.3"
+sp1-helper = "=5.2.3"
+sp1-sdk = { version = "=5.2.3", features = ["network"] }
+sp1-zkvm = "=5.2.3"
 superstruct = "0.10"
 syn-solidity = "1.3"
 thiserror = "2.0"
@@ -60,11 +60,11 @@ tokio = "1.47.1"
 tracing = "0.1.41"
 tracing-forest = "0.2"
 tracing-subscriber = {version="0.3.20", features=["std", "fmt", "json"]}
-tree_hash = "0.10"
-tree_hash_derive = "0.10"
-typenum = "1.18"
+tree_hash = "=0.10.0"
+tree_hash_derive = "=0.10.0"
+typenum = "=1.19.0"
 # ssz_types = { version = "0.12.0", features = ["arbitrary", "cap-typenum-to-usize-overflow"], path = "../../ssz_types"  }
-ssz_types = { git = "https://github.com/lidofinance/ssz_types", features = ["arbitrary", "cap-typenum-to-usize-overflow"] }
+ssz_types = { git = "https://github.com/lidofinance/ssz_types", rev = "c81e87812a9449b89d6d7a31a375090466b90544", features = ["arbitrary", "cap-typenum-to-usize-overflow"] }
 
 sp1-lido-accounting-zk-shared = { path = "crates/shared" }
 sp1-lido-accounting-zk-scripts = { path = "crates/script" }
@@ -77,5 +77,5 @@ cargo-bundle-licenses = "2.0.0"
 
 [patch.crates-io]
 sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-4.0.0" }
-ethereum_hashing = { git = "https://github.com/sp1-patches/ethereum_hashing", branch = "sp1-patch-0.7.0" }
+ethereum_hashing = { git = "https://github.com/sp1-patches/ethereum_hashing", rev = "64f930bd7cf6aea108adad77ebb1997f1b2596ee" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-4.0.0" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@
 # platforms
 FROM --platform=linux/amd64 rust:1.88.0 AS builder
 WORKDIR /usr/src/sp1-lido-zk
-ARG SP1_VERSION=5.2.3
 ARG FOUNDRY_VERSION=1.4.4
-ENV SP1_VERSION=${SP1_VERSION}
 ENV FOUNDRY_VERSION=${FOUNDRY_VERSION}
-# copying this file separately to avoid busting cache and rerunning bootstrap on every file change
+# SP1_VERSION is derived from the sp1-zkvm version in Cargo.toml - bootstrap cache re-runs when it changes
+COPY Cargo.toml ./Cargo.toml
 COPY docker/docker_build_bootstrap.sh ./docker_build_bootstrap.sh
-RUN ./docker_build_bootstrap.sh
+RUN SP1_VERSION=$(sed -n 's/^sp1-zkvm = "=\([0-9.]*\)".*/\1/p' Cargo.toml) \
+    ./docker_build_bootstrap.sh
 # Install git for submodule initialization
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git=1:2.39.5-0+deb12u* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
 # FromPlatformFlagConstDisallowed warning intentional - otherwise program ELF files differ when built on different host 
 # platforms
-FROM --platform=linux/amd64 rust:1.88 AS builder
+FROM --platform=linux/amd64 rust:1.88.0 AS builder
 WORKDIR /usr/src/sp1-lido-zk
+ARG SP1_VERSION=5.2.3
+ARG FOUNDRY_VERSION=1.4.4
+ENV SP1_VERSION=${SP1_VERSION}
+ENV FOUNDRY_VERSION=${FOUNDRY_VERSION}
 # copying this file separately to avoid busting cache and rerunning bootstrap on every file change
 COPY docker/docker_build_bootstrap.sh ./docker_build_bootstrap.sh
 RUN ./docker_build_bootstrap.sh
 # Install git for submodule initialization
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git=1:2.39.5-0+deb12u* \
+    && rm -rf /var/lib/apt/lists/*
 # See .dockerignore for list of copied files
 COPY . .
 ENV PATH="$PATH:/root/.sp1/bin:/root/.foundry/bin"
@@ -22,9 +28,13 @@ RUN echo "$PRINT_ELF_SHA" && sha256sum target/elf-compilation/riscv32im-succinct
 
 # Cannot use alpine because we need glibc, and alpine uses musl. Between compiling for musl
 # (only for docker), and using slightly larger base image, the latter seems a lesser evil
-FROM --platform=linux/amd64 debian:stable-slim AS lido_sp1_oracle
+FROM --platform=linux/amd64 debian:12.6-slim AS lido_sp1_oracle
 WORKDIR /usr/data/sp1-lido-zk
-RUN apt-get update && apt install -y curl openssl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl=7.88.1-10+deb12u* \
+    openssl=3.0.18-1~deb12u* \
+    ca-certificates=20230311+deb12u1 \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/src/sp1-lido-zk/target/release/service /usr/local/bin/service
 COPY --from=builder /usr/src/sp1-lido-zk/target/release/deploy /usr/local/bin/deploy
 COPY --from=builder /usr/src/sp1-lido-zk/target/release/store_report /usr/local/bin/store_report

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,37 +1,34 @@
 # Dockerfile for reproducible integration testing and fixture generation
 # Forces linux/amd64 platform for consistent ELF binary builds
-FROM --platform=linux/amd64 rust:1.88
+FROM --platform=linux/amd64 rust:1.88.0
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    curl \
-    git \
-    jq \
-    openssl \
-    ca-certificates \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential=12.9* \
+    curl=7.88.1-10+deb12u* \
+    git=1:2.39.5-0+deb12u* \
+    jq=1.6* \
+    openssl=3.0.18-1~deb12u* \
+    ca-certificates=20230311+deb12u1 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace
 
-# Install SP1 toolchain
+# SP1_VERSION derived from Cargo.toml - matches main Dockerfile approach
+COPY Cargo.toml ./Cargo.toml
 COPY docker/docker_build_bootstrap.sh ./docker_build_bootstrap.sh
-RUN ./docker_build_bootstrap.sh && \
-    echo 'source /root/.bashrc' >> /root/.profile && \
-    /root/.sp1/bin/sp1up
-
-# Install Foundry (forge, cast, anvil)
-RUN /root/.foundry/bin/foundryup
+RUN SP1_VERSION=$(sed -n 's/^sp1-zkvm = "=\([0-9.]*\)".*/\1/p' Cargo.toml) \
+    ./docker_build_bootstrap.sh
 
 # Add toolchains to PATH
 ENV PATH="$PATH:/root/.sp1/bin:/root/.foundry/bin"
 
 # Install just (task runner)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin --tag 1.37.0
 
 # Copy workspace files for dependency caching
 # See .dockerignore for what gets copied
-COPY Cargo.toml Cargo.lock rust-toolchain ./
+COPY Cargo.lock rust-toolchain ./
 COPY crates/program/rust-toolchain ./crates/program/
 COPY crates ./crates
 
@@ -64,4 +61,3 @@ RUN echo "ELF SHA256:" && \
 # Environment variables for testing
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=1
-

--- a/crates/program/rust-toolchain
+++ b/crates/program/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88"
+channel = "1.88.0"
 components = ["llvm-tools", "rustc-dev"]

--- a/docker/docker_build_bootstrap.sh
+++ b/docker/docker_build_bootstrap.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 
+set -euo pipefail
+
+: "${SP1_VERSION:=5.2.3}"
+: "${FOUNDRY_VERSION:=1.4.4}"
+
 # Install SP1 to compile ZK program
-curl -L https://sp1.succinct.xyz > ./install_sp1up.sh
+curl -fsSL https://sp1.succinct.xyz -o ./install_sp1up.sh
 chmod u+x ./install_sp1up.sh
 ./install_sp1up.sh
 source /root/.bashrc
-sp1up
+sp1up --version "${SP1_VERSION}"
 
 # Install foundry to compile contracts
-curl -L https://foundry.paradigm.xyz > ./install_foundryup.sh
+curl -fsSL https://foundry.paradigm.xyz -o ./install_foundryup.sh
 chmod u+x ./install_foundryup.sh
 ./install_foundryup.sh
 source /root/.bashrc
-foundryup
+foundryup --install "${FOUNDRY_VERSION}"

--- a/docker/docker_build_bootstrap.sh
+++ b/docker/docker_build_bootstrap.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-: "${SP1_VERSION:=5.2.3}"
+: "${SP1_VERSION:?SP1_VERSION must be set (derived from sp1-zkvm version in Cargo.toml)}"
 : "${FOUNDRY_VERSION:=1.4.4}"
 
 # Install SP1 to compile ZK program

--- a/justfile
+++ b/justfile
@@ -226,9 +226,10 @@ update_meta:
 
 ### Docker (Production)
 docker_build *args:
-    docker build -t lido_sp1_oracle . --platform linux/amd64 --build-arg VERGEN_GIT_SHA=$(git rev-parse HEAD) {{args}} --debug --load
+    docker build -t lido_sp1_oracle . --platform linux/amd64 --build-arg VERGEN_GIT_SHA=$(git rev-parse HEAD) {{args}} --load
 
-docker_build_print_elf_sha: (docker_build "--build-arg PRINT_ELF_SHA=$(date +%s) --progress plain")
+docker_build_print_elf_sha *args:
+    just docker_build --build-arg PRINT_ELF_SHA=$(date +%s) --progress plain {{args}}
 
 # network: host is to allow connecting to anvil when run locally
 # Practically just docker-compose for lazy

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88"
+channel = "1.88.0"
 components = ["llvm-tools", "rustc-dev"]


### PR DESCRIPTION
Problem

  The verification key (vkey) is derived from the compiled ZK program ELF. Any toolchain or dependency version drift — even a patch release — can silently produce a different vkey, breaking proof verification on-chain. Several components were unpinned or inconsistently pinned across Docker, CI, and Cargo.

  Changes

  Single source of truth for SP1 version
  - SP1_VERSION is no longer hardcoded in Dockerfile and docker_build_bootstrap.sh; it is now extracted at build time from the sp1-zkvm version in Cargo.toml via sed
  - Bootstrap script errors explicitly if SP1_VERSION is not provided

  Docker (Dockerfile, Dockerfile.test, docker_build_bootstrap.sh)
  - Base images pinned to exact patch versions: rust:1.88.0, debian:12.6-slim
  - All apt-get packages pinned with version constraints
  - SP1 toolchain: sp1up (latest) → sp1up --version $SP1_VERSION
  - Foundry: foundryup (latest) → foundryup --install 1.4.4
  - just installer pinned to 1.37.0
  - Fixed a bug in Dockerfile.test where an extra unversioned sp1up call overrode the version installed by bootstrap

  Cargo.toml
  - SP1 crates bumped from 5.2.1 to =5.2.3 (exact, matching toolchain)
  - ELF-critical crates pinned to exact versions matching Cargo.lock: alloy-primitives, alloy-sol-types, ethereum_ssz, tree_hash, tree_hash_derive, ethereum-types, ethereum_serde_utils, typenum, derive_more, arbitrary
  - ssz_types git dependency pinned with rev (previously tracked default branch HEAD)
  - ethereum_hashing patch pinned with rev instead of branch (branch tip could change)

  CI (combined-ci.yml)
  - Rust toolchain: --default-toolchain stable → 1.88.0
  - Foundry: version: nightly → v1.4.4
  - SP1: sp1up --version 5.2.1 → 5.2.3

  rust-toolchain (root and crates/program/)
  - channel = "1.88" → "1.88.0" to prevent drift across patch releases

  Why this matters

  Before this PR, cargo update on any of the ELF-critical crates, a new nightly Foundry build in CI, or an SP1 patch release could produce a different vkey without any code changes. CI was also building with SP1 5.2.1 while Docker used 5.2.3, meaning CI and production were producing different ELFs.